### PR TITLE
Updated nickel version to 0.8.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/Ryman/nickel-mustache"
 documentation = "http://ryman.github.io/nickel-mustache"
 
 [dependencies]
-nickel = "^0.7.1"
+nickel = "^0.8.1"
 mustache = "0.6"
 rustc-serialize = "0.3"
 


### PR DESCRIPTION
Effect: bug report went away

Error for refrence when nickel version == 0.7.3
"""
/cargo/registry/src/github.com-1ecc6299db9ec823/nickel-0.7.3/src/mimes.rs:5:16:
5:17 error: `$t:expr` is followed by `{`, which is not allowed for
`expr` fragments
/cargo/registry/src/github.com-1ecc6299db9ec823/nickel-0.7.3/src/mimes.rs:5
($($t:expr { $($name:ident, $as_s:pat, $subt:expr,)+ })+) => (
"""
